### PR TITLE
PVCM-114324 Remove setting oDataType in case of large file upload using Graph.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version "2.0-M6"
+version "2.0-M7"
 group "org.grails.plugins"
 
 apply plugin: "eclipse"

--- a/src/main/groovy/grails/plugins/mail/graph/sender/GraphMailSenderImpl.groovy
+++ b/src/main/groovy/grails/plugins/mail/graph/sender/GraphMailSenderImpl.groovy
@@ -78,7 +78,6 @@ class GraphMailSenderImpl extends OAuthMailSenderImpl {
             attachmentItem.attachmentType = AttachmentType.FILE
             attachmentItem.contentType = attachment.contentType ?: "application/octet-stream"
             attachmentItem.size = attachment.contentBytes.length as Long
-            attachmentItem.oDataType = attachment.oDataType
             attachmentItem.contentId = attachment.contentId
             if ((attachment.contentBytes.length / mbSize) > maxAttachmentSizeInMB) {
                 //more than 3MB size - send via upload session


### PR DESCRIPTION
Fixed Error:

incompatible type kinds were find. The type 'microsoft.graph.fileAttachment' was found to be of kind 'Entity' instead of the expected kind 'Complex'